### PR TITLE
Added support for generating typedef instances using mock()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,3 @@
 v1.0.x
+- added mocking for typedef structures (no verify/stubbing though)
 - changed mock param type in verify to Dynamic (avoids casting)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Or point to your local fork:
 
 ## Features
 
-Mock any class or interface (or typedef alias), including types with generics
+Mock any class or interface, including typedef aliases and types with generics (type paramaters)
 
 	var mockedClass = Mockatoo.mock(SomeClass);
 	var mockedInterface = Mockatoo.mock(SomeInterface);
@@ -94,8 +94,7 @@ A Mock class type will be generated that extends the Class (or Interface), stubb
 	var mockedClass = new SomeClassMocked();
 	var mockedInterface = new SomeInterfaceMocked();
 
-
-If a class requires Type paramaters then you can either use a typedef alias.
+	If a class requires Type paramaters then you can either use a typedef alias.
 
 	typedef FooBar = Foo<Bar>;
 
@@ -113,6 +112,14 @@ Both these generates the equivalent expressions:
 
 
 > Note: These usages are required in order to circumvent limitation of compiler with generics. You cannot compile `Foo.doSomething(Array<String>)`
+
+
+You can also 'mock' a typedef structure, however the
+generated object is not technically a mock, so does not support verification or stubbing.
+
+	typedef SomeTypeDef = {name:String}
+	...
+	var mockedTypDef = Mockatoo.mock(SomeTypeDef);
 
 
 ### Verifying Behaviour

--- a/src/mockatoo/Mockatoo.hx
+++ b/src/mockatoo/Mockatoo.hx
@@ -17,13 +17,13 @@ class Mockatoo
 	/**
 	Creates mock object of given class or interface.
 	
-	@param classToMock class or interface to mock
+	@param typeToMock class or interface to mock
 	@return new instance of generated Mock class
 	*/
-	@:macro static public function mock<T>(classToMock:ExprOf<Class<T>>, ?paramTypes:ExprOf<Array<Class<T>>>):ExprOf<T>
+	@:macro static public function mock<T>(typeToMock:ExprOf<Class<T>>, ?paramTypes:ExprOf<Array<Class<T>>>):ExprOf<T>
 	{
 		InitMacro.init();
-		var mock = new MockMaker(classToMock, paramTypes);
+		var mock = new MockMaker(typeToMock, paramTypes);
 		return mock.toExpr();
 	}
 

--- a/test/mockatoo/MockatooTest.hx
+++ b/test/mockatoo/MockatooTest.hx
@@ -337,6 +337,40 @@ class MockatooTest
 	}
 	#end
 
+	// ------------------------------------------------------------------------- typedef structures
+	
+	@Test
+	public function should_mock_typdef_structure():Void
+	{
+		var fields:Array<Field> = [];
+		addField(fields, "func", []);
+		var mock = Mockatoo.mock(TypedefStructure);
+
+		assertTypedefMockField(mock, "type", null);
+		assertTypedefMockField(mock, "title", null);
+		assertTypedefMockField(mock, "optionalTitle", null);
+		assertTypedefMockField(mock, "func", null, true);
+		assertTypedefMockField(mock, "optionalFunc", null, true);
+	}
+
+	function assertTypedefMockField(mock:Dynamic, fieldName:String, value:Dynamic, ?isFunc:Bool=false)
+	{
+		Assert.isTrue(Reflect.hasField(mock, fieldName));
+
+		var field = Reflect.field(mock, fieldName);
+
+		Assert.areEqual(isFunc, Reflect.isFunction(field));
+
+		if(isFunc)
+		{
+			Assert.areEqual(value, field());
+		}
+		else
+		{
+			Assert.areEqual(value, field);
+		}
+	}
+
 	// ------------------------------------------------------------------------- utilities
 
 	function assertMock(mock:Mock, cls:Class<Dynamic>, ?fields:Array<Field>, ?pos:haxe.PosInfos)

--- a/test/test/TestClasses.hx
+++ b/test/test/TestClasses.hx
@@ -205,14 +205,6 @@ class ExtendsTypedExtensionClass extends ExtendsTypedClass<String, String>
 	}	
 }
 
-typedef TypedefToSimpleInterface = SimpleInterface;
-typedef TypedefToSimpleClass = SimpleClass;
-typedef TypedefToStringTypedInterface = TypedInterface<String>;
-typedef TypedefToStringTypedClass = TypedClass<String>;
-
-typedef TypedefToImplementsTypedInterface = ImplementsTypedInterface<String, String>;
-typedef TypedefToExtendsTypedClass = ExtendsTypedClass<String, String>;
-
 class ClassWithPrivateReference
 {
 	public function new()
@@ -233,4 +225,38 @@ private class PrivateClass
 	{
 		
 	}
+}
+
+
+// ----------------------------------------------------------------------------- Typedef Aliases
+
+
+typedef TypedefToSimpleInterface = SimpleInterface;
+typedef TypedefToSimpleClass = SimpleClass;
+typedef TypedefToStringTypedInterface = TypedInterface<String>;
+typedef TypedefToStringTypedClass = TypedClass<String>;
+
+typedef TypedefToImplementsTypedInterface = ImplementsTypedInterface<String, String>;
+typedef TypedefToExtendsTypedClass = ExtendsTypedClass<String, String>;
+
+
+
+// ----------------------------------------------------------------------------- Typedef Structures
+
+
+typedef TypedefStructure = 
+{
+	var title:String;
+	var func:Void->String;
+	var type:SomeEnumType;
+	
+	@:optional var optionalTitle:String;
+	@:optional var optionalFunc:Void -> String;
+}
+
+
+enum SomeEnumType
+{
+	foo;
+	bar;
 }


### PR DESCRIPTION
Mockatoo can also generate an object from a typedef structure.

Firstly, define a typedef

```
typedef SomeTypedef =
{
    name:String,
    foo:Void->Void
}
```

Then Create an instance using mock()

```
var mock = Mockatoo.mock(SomeTypedef);
```

Limitations
- generate object is not an instance of mock, therefore no support for verification or stubbing
