### PR TITLE
Added Mockatoo.reset()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
 v1.0.x
 - added mocking for typedef structures (no verify/stubbing though)
 - changed mock param type in verify to Dynamic (avoids casting)
+- added Mockatoo.reset(mock) to reset stubs/verifications

--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ You can also set a custom callback when a method is invoked
 	Mockatoo.when(mock.foo("bar")).thenCall(f);
 
 
+### Other features
+
+You can reset a mock to remove any custom stubs and/or verifications
+
+	Mockatoo.reset(mock);
+	
+
 ## Known Limitations
 
 ### Mocking inlined methods
@@ -274,13 +281,6 @@ Partial mock that defers to concrete implementation if not stubbed
 
 	trace(hash.get(0)); // traces 'mocked'
 	trace(hash.get(1)); // traces 'b'
-
-
-**Resetting mock**
-
-Ability to reset a mock and all existing stubbings
-
-	Mockatoo.reset(mock);
 
 
 ## Credits

--- a/src/mockatoo/Mockatoo.hx
+++ b/src/mockatoo/Mockatoo.hx
@@ -98,6 +98,17 @@ class Mockatoo
 	{
 		return WhenMacro.create(expr);
 	}
+
+	/**
+	Resets a mock object. This removes any existing stubbings or verifications on
+	the methods of the instance
+	*/
+	static public function reset(mock:Dynamic)
+	{
+		Console.assert(mock != null, "Cannot verify [null] mock");
+		Console.assert(Std.is(mock, Mock), "Object is not an instance of mock");
+		return mock.mockProxy.reset();
+	}
 }
 
 /**

--- a/src/mockatoo/internal/MockProxy.hx
+++ b/src/mockatoo/internal/MockProxy.hx
@@ -17,13 +17,7 @@ class MockProxy
 	{
 		this.target = target;
 		targetClass = Type.getClass(target);
-		hash = new Hash();
-
-		var m = haxe.rtti.Meta.getType(targetClass);
-		targetClassName = cast m.mockatoo[0];
-
-		var fieldMeta = haxe.rtti.Meta.getFields(targetClass);
-		parseMetadata(fieldMeta);
+		reset();
 	}
 
 	/**
@@ -97,18 +91,19 @@ class MockProxy
 		return stub;
 	}
 
-	/*
-	public function thenReturn(value:T):Stubber
-	{
-		
-	}
-
-	public function thenThrow(value:Dynamic):Stubber
-	{
-
-	}
-
+	/**
+	Resets all stubs/verifications for the mock class
 	*/
+	public function reset()
+	{
+		hash = new Hash();
+
+		var m = haxe.rtti.Meta.getType(targetClass);
+		targetClassName = cast m.mockatoo[0];
+
+		var fieldMeta = haxe.rtti.Meta.getFields(targetClass);
+		parseMetadata(fieldMeta);
+	}
 
 	function parseMetadata(fields:Dynamic<Dynamic<Array<Dynamic>>>)
 	{

--- a/test/mockatoo/MockatooTest.hx
+++ b/test/mockatoo/MockatooTest.hx
@@ -371,6 +371,32 @@ class MockatooTest
 		}
 	}
 
+	// ------------------------------------------------------------------------- reset
+
+	@Test
+	public function should_reset_verifications()
+	{
+		var instance = Mockatoo.mock(SimpleClass);
+
+		instance.test();
+		Mockatoo.reset(instance);
+
+		Mockatoo.verify(instance, never).test();
+	}
+
+	@Test
+	public function should_reset_stubs()
+	{
+		var instance = Mockatoo.mock(SimpleClass);
+
+		Mockatoo.when(instance.test()).thenThrow("exception");
+		Mockatoo.reset(instance);
+
+		instance.test();
+		Assert.isTrue(true);//otherwise an expception would have been thrown
+	}
+
+
 	// ------------------------------------------------------------------------- utilities
 
 	function assertMock(mock:Mock, cls:Class<Dynamic>, ?fields:Array<Field>, ?pos:haxe.PosInfos)

--- a/test/mockatoo/internal/MockProxyTest.hx
+++ b/test/mockatoo/internal/MockProxyTest.hx
@@ -199,6 +199,7 @@ class MockProxyTest
 		var mock = mockatoo.Mockatoo.mock(ClassToMock);
 		instance = new MockProxy(mock);
 
+
 		var stub = instance.stub("two", [1,2]);
 
 		var wasCalled:Bool = false;
@@ -213,6 +214,44 @@ class MockProxyTest
 		instance.callMethodAndReturn("two", [1,2], 0);
 
 		Assert.isTrue(wasCalled);
+	}
+
+	// ------------------------------------------------------------------------- reset
+
+
+	@Test
+	public function should_reset_stubbing():Void
+	{
+		var mock = mockatoo.Mockatoo.mock(ClassToMock);
+		instance = new MockProxy(mock);
+		
+		instance.stub("two", [1,2]).thenReturn(4);
+
+		var result = instance.callMethodAndReturn("two", [1,2], 0);
+
+		Assert.areEqual(4, result);
+
+		instance.reset();
+
+		result = instance.callMethodAndReturn("two", [1,2], 0);
+		Assert.areEqual(0, result);
+	}
+
+	@Test
+	public function should_reset_verifications():Void
+	{
+		var mock = mockatoo.Mockatoo.mock(ClassToMock);
+		
+		instance = new MockProxy(mock);
+		instance.callMethodAndReturn("two", [1,2], 0);
+		instance.reset();
+
+		try
+		{
+			instance.verify().two(1, 2);
+			Assert.fail("Expected VerificationException");
+		}
+		catch(e:VerificationException) {}
 	}
 }
 


### PR DESCRIPTION
Resets a mock's stubbings and verification counts.

```
Mockatoo.reset(mock);
```
