### PR TITLE
Fixed issue #23 - mock method with type parameters

### DIFF
--- a/src/mockatoo/macro/ClassFields.hx
+++ b/src/mockatoo/macro/ClassFields.hx
@@ -123,7 +123,7 @@ class ClassFields
 	}
 
 	/**
-		Recursively Rreplaces references to an abstract type <T> with a concrete Types
+		Recursively Replaces references to an abstract type <T> with a concrete Types
 		defined in a map (recursively updates param types as well)
 		(e.g. T, Array<T>, Interator<Null<T>>)
 	*/
@@ -255,7 +255,7 @@ class ClassFields
 									args:convertTFunArgsToFunctionArgs(args, paramMap),
 									ret: convertType(ret, paramMap),
 									expr:expr,
-									params:[]
+									params:convertParams(field.params,paramMap)
 								});
 
 							default: throw "not implemented for type [" + field.type + "]";
@@ -264,6 +264,23 @@ class ClassFields
 			}
 		}
 		return null;
+	}
+
+	static function convertParams(params:Array<TypeParameter>, paramMap:Array<TypeDeclaration>):Array<TypeParamDecl>
+	{
+		var results:Array<TypeParamDecl> = [];
+
+		for(param in params)
+		{
+			var complexType = convertType(param.t, paramMap);
+			var result = {
+				name:param.name,
+				constraints:[],
+				params:[]
+			}
+			results.push(result);
+		}
+		return results;
 	}
 
 	static function convertTFunArgsToFunctionArgs(args : Array<{ t : Type, opt : Bool, name : String }>, paramMap:Array<TypeDeclaration>):Array<FunctionArg>

--- a/src/mockatoo/macro/MockMaker.hx
+++ b/src/mockatoo/macro/MockMaker.hx
@@ -746,14 +746,14 @@ class MockMaker
 	function overrideField(field:Field, f:Function)
 	{
 		if (!isInterface)
-		field.access.unshift(AOverride);
+			field.access.unshift(AOverride);
 
 		var args:Array<Expr> = [];
 
 		for (arg in f.args)
 		{
 			arg.type = normaliseComplexType(arg.type);
-			args.push(macro $i{arg.name});
+			args.push(macro cast $i{arg.name});
 		}
 		
 		var eMockOutcome = createMockFieldExprs(field, args);

--- a/test/mockatoo/MockatooTest.hx
+++ b/test/mockatoo/MockatooTest.hx
@@ -729,6 +729,18 @@ class MockatooTest
 
 	}
 
+	@Test
+	public function should_mock_Issue23()
+	{
+		var real = new TypedMethod();
+		real.test(1);
+		Assert.isTrue(true);
+		
+		var mock = Mockatoo.mock(TypedMethod);
+		mock.test(1);
+		Mockatoo.verify(mock.test(1));
+	}
+
 	// ------------------------------------------------------------------------- utilities
 
 	function assertMock(mock:Mock, cls:Class<Dynamic>, ?fields:Array<Field>, ?pos:haxe.PosInfos)

--- a/test/test/TestClasses.hx
+++ b/test/test/TestClasses.hx
@@ -241,6 +241,17 @@ class IntIterableClass extends TypedIterableClass<Int>
 	}
 }
 
+
+class TypedMethod
+{
+	public function new()
+	{
+		
+	}
+	public function test<T>(t:T)
+	{
+	}
+}
 // ---------------------- others
 
 class ClassWithPrivateReference
@@ -533,6 +544,13 @@ interface Issue18
 	var myVal(null, set): Dynamic;
 }
 
-interface Issue21 {
-    public function returnSomething(something:String, other:Int = 0):String;
+class Issue23
+{
+	public function new()
+	{
+
+	}
+	public function test<T>(t:T)
+	{
+	}
 }


### PR DESCRIPTION
Fixes compiler error when mocking method with type params (like the example below)

```
class TypedMethod
{
    public function new()
    {

    }
    public function test<T>(t:T)
    {
    }
}
```
