### PR TITLE
Null check on isVoidVoid()

### DIFF
--- a/src/mockatoo/macro/MockMaker.hx
+++ b/src/mockatoo/macro/MockMaker.hx
@@ -862,15 +862,18 @@ class MockMaker
 	*/
 	function isVoidVoid(type:ComplexType):Bool
 	{
-		switch (type)
+		if (type != null)
 		{
-			case TFunction(args,ret): 
-				if (args.length == 0 && !isNotVoid(ret))
-				{
-					return true;
-				}
-			case _:
-				return false;
+			switch (type)
+			{
+				case TFunction(args,ret): 
+					if (args.length == 0 && !isNotVoid(ret))
+					{
+						return true;
+					}
+				case _:
+					return false;
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
In case the current `type` was null (is sometimes the case 
when return type hints are not provided in the code but are 
left for type inference to figure out)

Without this check I was receiving this error:

```
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/macro/MockMaker.hx:865: characters 10-14 : Invalid field access : index
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/macro/MockMaker.hx:1000: characters 11-28 : Called from
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/macro/MockMaker.hx:848: characters 13-42 : Called from
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/macro/MockMaker.hx:517: characters 5-28 : Called from
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/macro/MockMaker.hx:491: characters 3-29 : Called from
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/macro/MockMaker.hx:329: characters 15-29 : Called from
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/macro/MockMaker.hx:243: characters 19-41 : Called from
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/macro/MockMaker.hx:99: characters 4-25 : Called from
<builtin>:1: character 0 : Called from
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/macro/MockMaker.hx:27: lines 27-1064 : Called from
/usr/lib/haxe/lib/mockatoo/3,1,1/mockatoo/Mockatoo.hx:25: characters 13-58 : Called from
src/ufront/test/TestUtils.hx:58: characters 13-31 : Called from
```

It might also be preferable to have a requirement that mocked classes use complete type signiatures on all methods and variables.  If this is what you'd prefer let me know and I'll create a pull request for that instead.
