### PR TITLE
Check against Map.IMap not `Map` and friends

### DIFF
--- a/src/mockatoo/internal/MockMethod.hx
+++ b/src/mockatoo/internal/MockMethod.hx
@@ -330,17 +330,11 @@ class MockMethod
 	{
 		if (value == null) return false;	
 		
-		if (Std.is(value, Array) || Std.is(value, Map)) return true;
-		// need to check these dirtectly because 'IntMap' does not return true for Std.is(value,Map)
-		if (Std.is(value, haxe.ds.IntMap)) return true;
-		if (Std.is(value, haxe.ds.ObjectMap)) return true;
-		if (Std.is(value, haxe.ds.StringMap)) return true;
-		if (Std.is(value, haxe.ds.WeakMap)) return true;
-		if (Std.is(value, haxe.ds.HashMap)) return true;
+		// Please note, we cannot check HashMap because it is an abstract, and does not have an iterator function at runtime.
+		if (Std.is(value, Array) || Std.is(value, Map.IMap)) return true;
 		
 		//Iterable
 		var iterator = Reflect.field(value, "iterator");
-		
 		if (Reflect.isFunction(iterator)) return true;
 
 		//Iterator


### PR DESCRIPTION
Somewhere on the path to 3.2 using `Std.id( obj, AbstractType )` has become disallowed, and I gather it never worked anyway - hence testing every type manually before.  

Checking against the `Map.IMap` interface does work.  (Though it is moving to `haxe.Constraints.IMap` for the next release...)
