### PR TITLE
Issue #42 - gen mock via @:mock and @:spy metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ Mock properties that are read or write only
 	mock.someGetter.calls(function(){return "foo"});
 
 
+Generate mocks via metadata by implementing `Mockatoo.MockTest` (requires munit)
+
+	class SomeTest implements mockatoo.MockTest
+	{
+		@:mock var mock:SomeClass;
+		@:spy var spy:SomeSpy;
+
+		@Test
+		public function someTestCase()
+		{
+			mock.something().returns("hello");
+			...
+		}
+	}
+
 
 ## How it works
 

--- a/src/mockatoo/MockTest.hx
+++ b/src/mockatoo/MockTest.hx
@@ -1,0 +1,18 @@
+package mockatoo;
+
+/**
+	Interface for automatically generating mock instances via metadata
+
+
+	````
+	@:mock var mock:SomeClass;
+	@:spy var spy:SomeClass;
+	````
+
+	Current supports munit test framework
+**/
+@:autoBuild(mockatoo.macro.MockTestMacro.build())
+interface MockTest
+{
+
+}

--- a/src/mockatoo/macro/MockTestMacro.hx
+++ b/src/mockatoo/macro/MockTestMacro.hx
@@ -1,0 +1,118 @@
+package mockatoo.macro;
+
+#if macro
+import haxe.macro.Compiler;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+import haxe.macro.Printer;
+import mockatoo.Mock;
+
+using StringTools;
+using haxe.macro.Tools;
+using mockatoo.macro.Tools;
+
+/**
+	Macro build to generate mock instance inside a test class
+*/
+class MockTestMacro
+{
+	static var befores:Array<Expr>;
+	static var afters:Array<Expr>;
+
+	static public function build()
+	{
+		befores = [];
+		afters = [];
+
+		var fields = Context.getBuildFields();
+
+		for(field in fields)
+		{
+			if(field.meta == null || field.meta.length == 0) continue;
+
+			switch(field.kind)
+			{
+				case FVar(t,e):
+					for(meta in field.meta)
+					{
+						if(meta.name == ":mock")
+							addMock(field, t, e);
+						else if(meta.name == ":spy")
+							addMock(field, t, e, true);
+					}
+					
+				case _:
+			}
+		}
+
+		if(befores.length > 0 || afters.length > 0)
+		{
+			if(Context.defined("munit"))
+			{
+				fields.push(addField("setupMockatoo", "Before", befores));
+				fields.push(addField("teardownMockatoo", "After", afters));
+			}
+			else
+				Context.warning("Unable to generate mocks: @:mock and @:spy require munit", Context.currentPos());
+			
+			return fields;	
+		}
+		
+		return null;
+	}
+
+	/**
+	Generates a function containing an array of `exprs`
+	**/
+	static function addField(name:String, meta:String, exprs:Array<Expr>)
+	{
+
+		var f:Function = 
+		{
+			args:[],
+			ret: null,
+			expr: macro $b{exprs},
+			params:[]
+		}
+
+		var field:Field = 
+		{
+			name:name,
+			meta:[{name:meta, params:[], pos:Context.currentPos()}],
+			kind: FieldType.FFun(f),
+			doc: null,
+			access: [Access.APublic],
+			pos:Context.currentPos()
+		}
+
+		return field;
+	}
+
+	/**
+	Appends exprs for setting up / tearing down each mock or spy
+	**/
+	static function addMock(field:Field, t:ComplexType, ?e:Expr, ?isSpy:Bool=false)
+	{
+		var type = t.toString();
+		var before:Expr = null;
+		var after:Expr = null;
+
+		if(isSpy)
+		{
+			before = macro $i{field.name} = Mockatoo.spy($i{type});
+			after = macro $i{field.name} = null;
+		}
+		else
+		{
+			before = macro $i{field.name} = Mockatoo.mock($i{type});
+			after = macro $i{field.name} = null;
+		}
+
+		befores.push(before);		
+		afters.push(after);		
+	}
+	
+}
+#end
+

--- a/test/mockatoo/MockatooMetadataTest.hx
+++ b/test/mockatoo/MockatooMetadataTest.hx
@@ -1,0 +1,46 @@
+package mockatoo;
+
+import massive.munit.util.Timer;
+import massive.munit.Assert;
+import massive.munit.async.AsyncFactory;
+import mockatoo.exception.VerificationException;
+import mockatoo.exception.StubbingException;
+import mockatoo.Mockatoo;
+import mockatoo.Mock;
+import test.TestClasses;
+import util.Asserts;
+import haxe.ds.StringMap;
+
+import mockatoo.Mockatoo.*;
+using mockatoo.Mockatoo;
+
+
+class MockatooMetadataTest implements mockatoo.MockTest
+{
+	@:mock var mock:SimpleClass;
+	@:spy var spy:SimpleClass;
+
+	public function new() 
+	{
+		
+	}
+	
+	// ------------------------------------------------------------------------- mocking
+
+	@Test
+	public function should_generate_mock():Void
+	{
+		Assert.isNotNull(mock);
+		Assert.isTrue(Std.is(mock, SimpleClass));
+		Assert.isTrue(Std.is(mock, Mock));
+	}
+
+	@Test
+	public function should_generate_spy():Void
+	{
+		Assert.isNotNull(spy);
+		Assert.isTrue(Std.is(spy, SimpleClass));
+		Assert.isTrue(Std.is(spy, Mock));
+	}
+
+}


### PR DESCRIPTION
Added support for generating mocks via metadata
