### PR TITLE
Add option to explicitly ignore inline methods in mock

### DIFF
--- a/src/mockatoo/macro/MockMaker.hx
+++ b/src/mockatoo/macro/MockMaker.hx
@@ -541,7 +541,7 @@ class MockMaker
 				{
 					#if no_inline
 						fields.push(field);
-					#else
+					#elseif !ignore_inline
 						Context.warning("Cannot mock inline method [" + id + "." + field.name + "]. Please set '--no-inline' compiler flag.", Context.currentPos());
 					#end
 


### PR DESCRIPTION
Users can opt to explicitly ignore inline methods without having warnings generated, by running the compiler with `-D ignore-inline`.

This solves #45.