### PR TITLE
Fix a compile error on JS target (fix #50)

### DIFF
--- a/src/mockatoo/macro/ClassFields.hx
+++ b/src/mockatoo/macro/ClassFields.hx
@@ -315,7 +315,7 @@ class ClassFields
 
 			var value:Null<Expr> = arg.opt ? arg.t.toComplexType().getDefaultValue() : null;
 
-			if (arg.opt && Tools.isStaticPlatform())
+			if (arg.opt)
 			{
 				//NOTE(Dom) - this is to prevent #9 - optional method args without a `?` cause compilation error
 				arg.opt = verifyOptionalArgIsActuallyNullable(arg);

--- a/src/mockatoo/macro/tool/ComplexTypes.hx
+++ b/src/mockatoo/macro/tool/ComplexTypes.hx
@@ -33,7 +33,7 @@ class ComplexTypes
 	*/
 	static public function getDefaultValue(type:ComplexType):Expr
 	{
-		if (type != null && Tools.isStaticPlatform())
+		if (type != null)
 		{
 			type = extractAbstractType(type);
 			


### PR DESCRIPTION
Using an optional function parameter of a basic type (such as `Bool`) results in compile errors.

For example, adding to the `Calculator` mock example:

```haxe
public function add (value1:Float, value2:Float, _round:Bool = false):Float {
	if (_round) return round(value1 + value2);
	return value1 + value2;
}
```

Results in this error:

```bash
src/math/Calculator.hx:13: lines 13-16 : Field add overloads parent class with different or incomplete type
src/math/Calculator.hx:13: lines 13-16 : value : Float -> value2 : Float -> ?_round : Null<Bool> -> Float should be value : Float -> value2 : Float -> ?_round : Bool -> Float
src/math/Calculator.hx:13: lines 13-16 : Null<Bool> should be Bool
```

Returning `null` as the default parameter on all dynamic targets for `macro.tools.ComplexTypes` results in forcing type `Bool` to be `Null<Bool>`, but this was not the original type. On current Haxe development builds, this is the error, on Haxe 3.2.1 it printed "src/Main.hx:28: characters 15-25 : math.CalculatorMocked has no field round" which is more confusing.

Removing the `Tools.isStaticPlatform()` conditional seems to fix this condition on JavaScript.