### PR TITLE
MatcherClass support for complex matching

### DIFF
--- a/src/mockatoo/Mockatoo.hx
+++ b/src/mockatoo/Mockatoo.hx
@@ -2,6 +2,7 @@ package mockatoo;
 
 import haxe.macro.Expr;
 import haxe.macro.Context;
+import mockatoo.internal.MatcherClass;
 import mockatoo.macro.InitMacro;
 import mockatoo.macro.MockMaker;
 import mockatoo.macro.VerifyMacro;
@@ -336,6 +337,7 @@ enum Matcher
 	isNotNull; // any non null value
 	any;  // wildcard for any value
 	customMatcher(f:Dynamic -> Bool); //custom function to verify value
+	matcherClass(instance:MatcherClass); //custom function to verify value
 }
 
 /**

--- a/src/mockatoo/internal/MatcherClass.hx
+++ b/src/mockatoo/internal/MatcherClass.hx
@@ -1,0 +1,12 @@
+package mockatoo.internal;
+
+/**
+ * Generic typedef for any matcher class that have a matches function. 
+ * This way you can use any 3rdparty framework like hamcrest to match against complex conditions.
+ * @author grosmar
+ */
+
+typedef MatcherClass =
+{
+	function matches(item:Dynamic):Bool;
+}

--- a/src/mockatoo/internal/MockMethod.hx
+++ b/src/mockatoo/internal/MockMethod.hx
@@ -297,6 +297,7 @@ class MockMethod
 						case Matcher.isNotNull: return actual != null;
 						case Matcher.any: return true;
 						case Matcher.customMatcher(f): return f(actual);
+						case Matcher.matcherClass(instance): return instance.matches(actual);
 					}
 				}
 			case TClass(_):

--- a/src/mockatoo/internal/MockMethod.hx
+++ b/src/mockatoo/internal/MockMethod.hx
@@ -1,4 +1,5 @@
 package mockatoo.internal;
+import haxe.Constraints.IMap;
 import mockatoo.exception.VerificationException;
 import mockatoo.exception.StubbingException;
 import mockatoo.Mockatoo;
@@ -332,7 +333,7 @@ class MockMethod
 		if (value == null) return false;	
 		
 		// Please note, we cannot check HashMap because it is an abstract, and does not have an iterator function at runtime.
-		if (Std.is(value, Array) || Std.is(value, Map.IMap)) return true;
+		if (Std.is(value, Array) || Std.is(value, IMap)) return true;
 		
 		//Iterable
 		var iterator = Reflect.field(value, "iterator");

--- a/src/mockatoo/macro/MockTestMacro.hx
+++ b/src/mockatoo/macro/MockTestMacro.hx
@@ -68,9 +68,6 @@ class MockTestMacro
 
 		if (befores.length == 0 || afters.length == 0) return null;
 
-		if (!Context.defined("munit"))
-			Context.warning("Unable to generate mocks - @:mock and @:spy require munit", Context.currentPos());
-
 		if (beforeField == null)
 		{
 			beforeField = createField(FIELD_SETUP, META_BEFORE, befores);


### PR DESCRIPTION
Hi,

I've extended your Matcher enum with a new type: matcherClass

This way you can provide classes instead of just functions. 

Also created a MatcherClass typedef for it, so the system is independent from any concrete implementation.

I did it to use hamcrest for argument checking, this way i call use all the crazy hamcrest Matchers for checking the conditions.

The usage is pretty simple after:
someMock.someFunction(cast matcherClass(endsWith("Bar")));

And as an addition I've removed the warning, if there is no munit defined, because it works with any test runner that is based on annotations. (like hexUnit https://github.com/DoclerLabs/hexUnit).

I want to modify later the macro to be able to receive configuration for the annotation and field names from outside.

I hope you like the modification.

Cheers,
Balazs
