### PR TITLE
Use haxe.Constraints.IMap instead of Map.IMap for haxe versions > 3.2

### DIFF
--- a/src/mockatoo/internal/MockMethod.hx
+++ b/src/mockatoo/internal/MockMethod.hx
@@ -331,7 +331,11 @@ class MockMethod
 		if (value == null) return false;	
 		
 		// Please note, we cannot check HashMap because it is an abstract, and does not have an iterator function at runtime.
+#if (haxe_ver <= "3.2")
+		if (Std.is(value, Array) || Std.is(value, haxe.Constraints.IMap)) return true;
+#else
 		if (Std.is(value, Array) || Std.is(value, Map.IMap)) return true;
+#end
 		
 		//Iterable
 		var iterator = Reflect.field(value, "iterator");


### PR DESCRIPTION
This fixes the warning mentioned in issues #55 & #48. The warning refers to use of the deprecated Map.IMap. This PR changes that to haxe.Constraints.IMap. It maintains compatibility with older versions by checking the haxe_ver compiler flag.

See https://github.com/HaxeFoundation/haxe/commit/4e8152a6829c79da27100204ca1fe4284f1b8a6d.
