### PR TITLE
Fix "install from GitHub" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Install current official release from haxelib (3.x)
 
 	haxelib install mockatoo
 
-Install the latest directly from github:
+Install the latest directly from GitHub:
 
-	haxelib git mockatoo https://github.com/misprintt/mockatoo.git src
+	haxelib git mockatoo https://github.com/misprintt/mockatoo master src
 
 Or point to your local fork:
 


### PR DESCRIPTION
Haxelib expects the branch before the source path argument. Not sure if this changed at some point.